### PR TITLE
docs: :memo: Remove condescending "simply" from readme and website.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Feel free to use this API for demos and fun things, I'd avoid using it for anyth
 
 ### GraphQL
 
-Primarily this is meant to be a GraphQL API. Simply fire queries to the following endpoint:
+Primarily this is meant to be a GraphQL API. You can send GraphQL queries from your GraphQL Client to the following endpoint:
 
 ```
 https://pride.dev/api/graphql

--- a/data/content/Homepage.md
+++ b/data/content/Homepage.md
@@ -6,7 +6,7 @@ Feel free to use this API for demos and fun things, I'd avoid using it for anyth
 
 ### GraphQL
 
-Primarily this is meant to be a GraphQL API. Simply fire queries to the following endpoint:
+Primarily this is meant to be a GraphQL API. You can send GraphQL queries from your GraphQL Client to the following endpoint:
 
 ```
 https://pride.dev/api/graphql
@@ -154,7 +154,7 @@ Hi I'm [Joe Hart](https://www.joehart.co.uk) 👋. You can find me on [twitter](
 
 ### Adding flags
 
-Flags are stored in the `flags` folder. To add a new one simply:
+Flags are stored in the `flags` folder. To add a new one you can:
 
 1. Create a new js file with the id of the flag `flagid.js`
 2. Fill the flag out with it's info.


### PR DESCRIPTION
Remove some condescending "simply" I let in there and make it clearer about accessing GraphQL endpoints